### PR TITLE
check version place holder exists in schema url before setting it

### DIFF
--- a/check.go
+++ b/check.go
@@ -74,7 +74,14 @@ func checkFunc(cmd *cobra.Command, _ []string) {
 			return
 		}
 
-		url := fmt.Sprintf(SchemaURL, getVersionMinor(core.KrakendVersion))
+		var url string
+		if strings.Contains(SchemaURL, "v%s") {
+			url = fmt.Sprintf(SchemaURL, getVersionMinor(core.KrakendVersion))
+		} else {
+			// the global schema url var might have been set at build time
+			// to something different
+			url = SchemaURL
+		}
 		sch, err := jsonschema.Compile(url)
 		if err != nil {
 			cmd.Println(errorMsg("ERROR compiling the schema:") + fmt.Sprintf("\t%s\n", err.Error()))


### PR DESCRIPTION
Just in case we want to set the SchemaURL at build time without a placeholder for the `KrakendVersion` environment var, we can check if it contains the `v%s` to be filled.