### PR TITLE
Remove log line on run command

### DIFF
--- a/run.go
+++ b/run.go
@@ -20,6 +20,5 @@ func runFunc(cmd *cobra.Command, _ []string) {
 	if port != 0 {
 		serviceConfig.Port = port
 	}
-	cmd.Printf("Parsing configuration file: %s\n", cfgFile)
 	run(serviceConfig)
 }


### PR DESCRIPTION
The `run` command prints a "Parsing configuration file" log line that is supposed to be an application log, but doesn't honor the `telemetry/logging` configuration as it doesn't use the logger.

This log line can be assumed as a problem if a customer configures a minimum log level to WARNING, while it's only an info line.

There's no easy way to print that line using the application logger, since the config file has not been parsed yet, nor the actual logger. It's easier to just remove the line.